### PR TITLE
Add CLI interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Setup PHP with required extensions, php.ini configuration, code-coverage support
   - [Multi-Arch Setup](#multi-arch-setup)
   - [Self Hosted Setup](#self-hosted-setup)
   - [Local Testing Setup](#local-testing-setup)
+  - [CLI Usage](#cli-usage)
   - [JIT Configuration](#jit-configuration)
   - [Cache Extensions](#cache-extensions)
   - [Cache Composer Dependencies](#cache-composer-dependencies)
@@ -742,6 +743,14 @@ act -P ubuntu-24.04=shivammathur/node:2404
 
 # For runs-on: ubuntu-22.04
 act -P ubuntu-22.04=shivammathur/node:2204
+```
+
+### CLI Usage
+
+> Run `setup-php` directly without GitHub Actions.
+
+```bash
+node dist/cli.js --php-version=8.4 --extensions=xdebug
 ```
 
 ### JIT Configuration

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+const {run} = require('./index.js');
+function parseArgs(args){
+  const options = {};
+  for(let i=0;i<args.length;i++){
+    const arg=args[i];
+    if(arg.startsWith('--')){
+      const eq=arg.indexOf('=');
+      if(eq!==-1){
+        const key=arg.slice(2,eq);
+        const val=arg.slice(eq+1);
+        options[key]=val;
+      }else{
+        const key=arg.slice(2);
+        const val=args[i+1] && !args[i+1].startsWith('--') ? args[++i] : 'true';
+        options[key]=val;
+      }
+    }
+  }
+  return options;
+}
+async function main(){
+  const options=parseArgs(process.argv.slice(2));
+  for(const [k,v] of Object.entries(options)){
+    process.env[k]=v;
+  }
+  await run();
+}
+main().catch(err=>{console.error(err);process.exit(1);});

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "private": false,
   "description": "Setup PHP for use with GitHub Actions",
   "main": "lib/install.js",
+  "bin": {
+    "setup-php": "dist/cli.js"
+  },
   "types": "lib/install.d.ts",
   "directories": {
     "lib": "lib",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+import {run} from './install';
+
+function parseArgs(args: string[]): Record<string,string> {
+  const options: Record<string, string> = {};
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg.startsWith('--')) {
+      const eq = arg.indexOf('=');
+      if (eq !== -1) {
+        const key = arg.slice(2, eq);
+        const val = arg.slice(eq + 1);
+        options[key] = val;
+      } else {
+        const key = arg.slice(2);
+        const val = args[i + 1] && !args[i + 1].startsWith('--') ? args[++i] : 'true';
+        options[key] = val;
+      }
+    }
+  }
+  return options;
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  for (const [key, value] of Object.entries(options)) {
+    process.env[key] = value;
+  }
+  await run();
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a small CLI wrapper in TypeScript
- include compiled `dist/cli.js`
- expose it via `bin` property in package.json
- document CLI usage in README

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint module missing)*

------
https://chatgpt.com/codex/tasks/task_e_685a3e423b148333bbc74afd18326be0